### PR TITLE
Switch to ducc 0.1 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,6 @@ authors = [
 edition = "2018"
 
 [dependencies]
-ducc = { git = "https://github.com/SkylerLipthay/ducc", rev = "558a0ec83cbb8aff57043cfafdb3d728cd509211" }
+ducc = "0.1.0"
 html2md = "0.2.9"
 once_cell = "0.2.2"


### PR DESCRIPTION
On [NixOS](https://nixos.org/), we try to package texlab and [we are getting some weird errors from our build system](https://github.com/NixOS/nixpkgs/issues/67934#issuecomment-527268487). Not sure why these errors occur and under the complete admittance this is our fault, we noticed these are related to ducc being used straight from it's Git repo. 

Since 8 days ago, [ducc is released on crates.io](https://crates.io/crates/ducc), I think it might help us and not hurt you if you'll use the version published on crates.io.

`cargo build` and `cargo test` work in this repo so I'm suggesting this change here. I'm trying to test texlab with it's `Cargo.toml` pointing to my version of `citeproc` but I'm encountering other errors which are not relevant here.